### PR TITLE
search datasources 0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+data/

--- a/chains/query_data_chain/modules/embedding.py
+++ b/chains/query_data_chain/modules/embedding.py
@@ -4,22 +4,6 @@ from dotenv import load_dotenv
 import os
 load_dotenv()
 
-# from langchain_chroma import Chroma
-# from langchain_openai import OpenAIEmbeddings
-
-# # Load your documents and create embeddings
-# documents = ['a','b','c']  # Load your documents here
-# embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
-# print(embeddings)
-
-# # Create the vector store
-# vector_store = Chroma.from_documents(documents, embeddings)
-
-# vector_store.add_documents(documents)
-
-# results = vector_store.similarity_search("your query here")
-
-
 client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
 
 def get_embedding_openai(text, model="text-embedding-3-small"):
@@ -30,7 +14,5 @@ def cosine_similarity(vec1, vec2):
     """Calculate the cosine similarity between two vectors."""
     return np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2))
 
-# def create_chroma_vector_store():
-#     print('build a vector')
 
 

--- a/chains/query_data_chain/modules/embedding.py
+++ b/chains/query_data_chain/modules/embedding.py
@@ -1,0 +1,36 @@
+import numpy as np
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+load_dotenv()
+
+# from langchain_chroma import Chroma
+# from langchain_openai import OpenAIEmbeddings
+
+# # Load your documents and create embeddings
+# documents = ['a','b','c']  # Load your documents here
+# embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+# print(embeddings)
+
+# # Create the vector store
+# vector_store = Chroma.from_documents(documents, embeddings)
+
+# vector_store.add_documents(documents)
+
+# results = vector_store.similarity_search("your query here")
+
+
+client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def get_embedding_openai(text, model="text-embedding-3-small"):
+   text = text.replace("\n", " ")
+   return client.embeddings.create(input = [text], model=model).data[0].embedding
+
+def cosine_similarity(vec1, vec2):
+    """Calculate the cosine similarity between two vectors."""
+    return np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2))
+
+# def create_chroma_vector_store():
+#     print('build a vector')
+
+

--- a/chains/query_data_chain/modules/graphql.py
+++ b/chains/query_data_chain/modules/graphql.py
@@ -1,0 +1,105 @@
+import tableauserverclient as TSC
+from dotenv import load_dotenv
+import os
+
+def get_tableau_client():
+    load_dotenv()
+    tableau_server = 'https://' + os.getenv('TABLEAU_DOMAIN')
+    tableau_pat_name = os.getenv('PAT_NAME')
+    tableau_pat_secret = os.getenv('PAT_SECRET')
+    tableau_sitename = os.getenv('SITE_NAME')
+    tableau_auth = TSC.PersonalAccessTokenAuth(tableau_pat_name, tableau_pat_secret, tableau_sitename)
+    server = TSC.Server(tableau_server, use_server_version=True)
+    return server, tableau_auth
+
+def fetch_dashboard_data_old(server, auth):
+    with server.auth.sign_in(auth):
+        # Query the Metadata API and store the response in resp
+        query = """
+            query GetAllDashboards {
+                dashboards {
+                    id
+                    name
+                    path
+                    workbook {
+                        id
+                        name
+                        luid
+                        projectName
+                        tags {
+                            name
+                        }
+                        sheets {
+                            id
+                            name
+                            createdAt
+                            updatedAt
+                            sheetFieldInstances {
+                                name
+                                description
+                                isHidden
+                                id
+                            }
+                            worksheetFields{
+                                name
+                                description
+                                isHidden
+                                formula
+                                aggregation
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        """
+        resp = server.metadata.query(query)
+        return resp['data']['dashboards']
+
+def fetch_dashboard_data(server, auth):
+    with server.auth.sign_in(auth):
+        # Read the GraphQL query from the file
+        query_file_path = os.path.join('tools','queryData','prompts', 'tab_dashboard_fields.graphql')
+        with open(query_file_path, 'r') as f:
+            query = f.read()
+        # Query the Metadata API and store the response in resp
+        resp = server.metadata.query(query)
+        return resp['data']['dashboards']
+    
+def fetch_sheets_data(server, auth):
+    with server.auth.sign_in(auth):
+        # Read the GraphQL query from the file
+        query_file_path = os.path.join('tools','queryData','prompts', 'tab_sheets.graphql')
+        with open(query_file_path, 'r') as f:
+            query = f.read()
+        # Query the Metadata API and store the response in resp
+        resp = server.metadata.query(query)
+        return resp['data']['sheets']
+    
+def fetch_datasources(server, auth):
+    with server.auth.sign_in(auth):
+        # Read the GraphQL query from the file
+        query_file_path = os.path.join('tools','queryData','prompts', 'tab_datasources.graphql')
+        with open(query_file_path, 'r') as f:
+            query = f.read()
+        # Query the Metadata API and store the response in resp
+        resp = server.metadata.query(query)
+        return resp['data']['publishedDatasources']
+
+def main():
+    server, auth = get_tableau_client()
+    # dashboards = fetch_dashboard_data(server, auth)
+    # sheets = fetch_sheets_data(server, auth)
+    datasources = fetch_datasources(server, auth)
+    for datasource in datasources:
+        print(datasource)
+
+    # for sheet in sheets:
+    #     print(sheet)
+
+    # Print the result
+    # for dashboard in dashboards:
+    #     print(f"Dashboard ID: {dashboard['id']}, Name: {dashboard['name']}, Path: {dashboard['path']}")
+
+if __name__ == "__main__":
+    main()

--- a/chains/query_data_chain/modules/graphql.py
+++ b/chains/query_data_chain/modules/graphql.py
@@ -15,7 +15,7 @@ def get_tableau_client():
 def fetch_dashboard_data(server, auth):
     with server.auth.sign_in(auth):
         # Read the GraphQL query from the file
-        query_file_path = os.path.join('tools','queryData','prompts', 'tab_dashboard_fields.graphql')
+        query_file_path = os.path.join('query_data_chain','modules','prompts', 'tab_dashboard_fields.graphql')
         with open(query_file_path, 'r') as f:
             query = f.read()
         # Query the Metadata API and store the response in resp
@@ -25,7 +25,7 @@ def fetch_dashboard_data(server, auth):
 def fetch_sheets_data(server, auth):
     with server.auth.sign_in(auth):
         # Read the GraphQL query from the file
-        query_file_path = os.path.join('tools','queryData','prompts', 'tab_sheets.graphql')
+        query_file_path = os.path.join('query_data_chain','modules','prompts','tab_sheets.graphql')
         with open(query_file_path, 'r') as f:
             query = f.read()
         # Query the Metadata API and store the response in resp
@@ -36,7 +36,7 @@ def fetch_datasources(server, auth):
     with server.auth.sign_in(auth):
 
         # Read the GraphQL query from the file
-        query_file_path = os.path.join('tools','queryData','prompts', 'tab_datasources.graphql')
+        query_file_path = os.path.join('query_data_chain','modules','prompts','tab_datasources.graphql')
         with open(query_file_path, 'r') as f:
             query = f.read()
 

--- a/chains/query_data_chain/modules/prompts/tab_dashboard_fields.graphql
+++ b/chains/query_data_chain/modules/prompts/tab_dashboard_fields.graphql
@@ -1,0 +1,36 @@
+query GetAllDashboards {
+    dashboards {
+        id
+        name
+        path
+        workbook {
+            id
+            name
+            luid
+            projectName
+            tags {
+                name
+            }
+            sheets {
+                id
+                name
+                createdAt
+                updatedAt
+                sheetFieldInstances {
+                    name
+                    description
+                    isHidden
+                    id
+                }
+                worksheetFields{
+                    name
+                    description
+                    isHidden
+                    formula
+                    aggregation
+                    id
+                }
+            }
+        }
+    }
+}

--- a/chains/query_data_chain/modules/prompts/tab_datasources.graphql
+++ b/chains/query_data_chain/modules/prompts/tab_datasources.graphql
@@ -1,0 +1,28 @@
+query GetPublishedDatasources {
+    publishedDatasources{
+      id
+      luid
+      uri
+      vizportalId
+      vizportalUrlId
+      name
+      hasExtracts
+      createdAt
+      updatedAt
+      extractLastUpdateTime
+      extractLastRefreshTime
+      extractLastIncrementalUpdateTime
+      projectName
+      containerName
+      isCertified
+      description
+      fields {
+        id
+        name
+        fullyQualifiedName
+        description
+        isHidden
+        folderName
+      }
+    }
+}

--- a/chains/query_data_chain/modules/prompts/tab_sheets.graphql
+++ b/chains/query_data_chain/modules/prompts/tab_sheets.graphql
@@ -1,0 +1,17 @@
+query sheets{
+  sheets {
+    id
+    luid
+    name
+    path
+    createdAt
+    updatedAt
+    index
+    workbook {
+      luid
+    }
+    containedInDashboards {
+      luid
+    }
+  }
+}

--- a/chains/query_data_chain/rag_demo.py
+++ b/chains/query_data_chain/rag_demo.py
@@ -58,10 +58,6 @@ else:
         # Remove any nested data structures from metadata (e.g., lists, dicts)
         metadata = {k: convert_to_string(v) for k, v in metadata.items() if isinstance(v, (str, int, float, bool, dict, list))}
 
-        # Embedding step not need, using auto with Chroma
-        #embedding = get_embedding_openai(text_to_embed)
-        #embeddings.append(embedding)
-
         documents.append(text_to_embed)
         ids.append(unique_id)
         

--- a/chains/query_data_chain/rag_demo.py
+++ b/chains/query_data_chain/rag_demo.py
@@ -1,0 +1,123 @@
+from modules import graphql
+import chromadb
+import numpy as np
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+load_dotenv()
+import chromadb.utils.embedding_functions as embedding_functions
+
+openai_client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def get_embedding_openai(text, model="text-embedding-3-small"):
+   text = text.replace("\n", " ")
+   return openai_client.embeddings.create(input = [text], model=model).data[0].embedding
+
+
+openai_ef = embedding_functions.OpenAIEmbeddingFunction(
+                api_key=os.getenv('OPENAI_API_KEY'),
+                model_name="text-embedding-3-small"
+            )
+
+def convert_to_string(value):
+    if isinstance(value, dict):
+        return str(value)
+    elif isinstance(value, list):
+        return ', '.join(map(str, value))
+    else:
+        return str(value)
+
+server, auth = graphql.get_tableau_client()
+datasources = graphql.fetch_datasources(server, auth)
+
+# Initialise Chroma
+chroma_client = chromadb.PersistentClient(path="data")
+collection_name = 'tableau_datasource_RAG_search'
+collection = chroma_client.get_collection(name=collection_name, embedding_function=openai_ef)
+
+if collection:
+    print("Collection exists.")
+    # Run your series of code here
+else:
+    print("Collection does not exist. Creating collection...")
+    documents = []
+    embeddings = []
+    ids = []
+    metadatas = []
+
+    for datasource in datasources:
+        # Extract the text to embed
+        text_to_embed = datasource['dashboard_overview']
+
+        # Extract the unique identifier
+        unique_id = datasource['id']
+
+        # Prepare metadata (exclude 'dashboard_overview' and 'id')
+        metadata = {k: v for k, v in datasource.items() if k not in ['dashboard_overview', 'id']}
+
+        # Remove any nested data structures from metadata (e.g., lists, dicts)
+        metadata = {k: convert_to_string(v) for k, v in metadata.items() if isinstance(v, (str, int, float, bool, dict, list))}
+
+        # Embedding step not need, using auto with Chroma
+        #embedding = get_embedding_openai(text_to_embed)
+        #embeddings.append(embedding)
+
+        documents.append(text_to_embed)
+        ids.append(unique_id)
+        
+        metadatas.append(metadata)
+    
+    # Create vector db with openai embedding
+    collection = chroma_client.get_or_create_collection(name=collection_name, embedding_function=openai_ef)
+
+    collection.add(
+        documents=documents,
+        metadatas=metadatas,
+        ids=ids
+    )
+
+# to Reset vector db
+# # chroma_client.delete_collection(name=collection_name)
+# collection = chroma_client.get_or_create_collection(name=collection_name, embedding_function=openai_ef)
+
+results = collection.query(
+    query_texts=["Why is my dashboard slow?"], 
+    n_results=2 
+)
+
+metadatas = results['metadatas']
+distances = results['distances']
+
+# Initialize an empty list to store extracted data
+extracted_data = []
+
+for meta_list, dist_list in zip(metadatas, distances):
+    for metadata, distance in zip(meta_list, dist_list):
+        name = metadata.get('name', 'N/A')
+        uri = metadata.get('uri', 'N/A')
+        luid = metadata.get('luid', 'N/A')
+        isCertified = metadata.get('isCertified', 'N/A')
+        updatedAt = metadata.get('updatedAt', 'N/A')
+        
+        # Append the extracted data to the list, including 'distance'
+        extracted_data.append({
+            'name': name,
+            'uri': uri,
+            'luid': luid,
+            'isCertified': isCertified,
+            'updatedAt': updatedAt,
+            'distance': distance
+        })
+
+
+for item in extracted_data:
+    print(f"Name: {item['name']}")
+    print(f"URI: {item['uri']}")
+    print(f"LUID: {item['luid']}")
+    print(f"Certified?: {item['isCertified']}")
+    print(f"Last Update: {item['updatedAt']}")
+    print(f"Vector distance: {item['distance']}")
+    print("-" * 40)
+
+
+

--- a/chains/query_data_chain/rag_demo_flask.py
+++ b/chains/query_data_chain/rag_demo_flask.py
@@ -1,0 +1,127 @@
+from flask import Flask, request, jsonify, render_template
+from modules import graphql
+import chromadb
+import numpy as np
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+import chromadb.utils.embedding_functions as embedding_functions
+
+# Load environment variables
+load_dotenv()
+
+# Initialize Flask app
+app = Flask(__name__)
+
+openai_client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+
+def get_embedding_openai(text, model="text-embedding-3-small"):
+   text = text.replace("\n", " ")
+   return openai_client.embeddings.create(input = [text], model=model).data[0].embedding
+
+
+openai_ef = embedding_functions.OpenAIEmbeddingFunction(
+                api_key=os.getenv('OPENAI_API_KEY'),
+                model_name="text-embedding-3-small"
+            )
+
+def convert_to_string(value):
+    if isinstance(value, dict):
+        return str(value)
+    elif isinstance(value, list):
+        return ', '.join(map(str, value))
+    else:
+        return str(value)
+    
+# Initialize the Chroma client
+chroma_client = chromadb.PersistentClient(path="data")
+collection_name = 'tableau_datasource_RAG_search'
+
+# Try to get the collection
+try:
+    collection = chroma_client.get_collection(name=collection_name, embedding_function=openai_ef)
+    print("Collection exists.")
+except Exception as e:
+    print("Collection does not exist. Creating collection...")
+    # Fetch data from Tableau
+    server, auth = graphql.get_tableau_client()
+    datasources = graphql.fetch_datasources(server, auth)
+
+    documents = []
+    ids = []
+    metadatas = []
+
+    for datasource in datasources:
+        # Extract the text to embed
+        text_to_embed = datasource['dashboard_overview']
+
+        # Extract the unique identifier
+        unique_id = datasource['id']
+
+        # Prepare metadata (exclude 'dashboard_overview' and 'id')
+        metadata = {k: v for k, v in datasource.items() if k not in ['dashboard_overview', 'id']}
+
+        # Convert metadata values to strings
+        metadata = {k: convert_to_string(v) for k, v in metadata.items() if isinstance(v, (str, int, float, bool, dict, list))}
+
+        documents.append(text_to_embed)
+        ids.append(unique_id)
+        metadatas.append(metadata)
+
+    # Create the collection and add data
+    collection = chroma_client.get_or_create_collection(name=collection_name, embedding_function=openai_ef)
+    collection.add(
+        documents=documents,
+        metadatas=metadatas,
+        ids=ids
+    )
+
+# Route to display the search form
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('search.html')
+
+# Route to handle search queries
+@app.route('/search', methods=['POST'])
+def search():
+    # Get the user's query from the form
+    user_input = request.form.get('query')
+    if not user_input:
+        return jsonify({"error": "No query provided"}), 400
+
+    # Perform the query
+    results = collection.query(
+        query_texts=[user_input],
+        n_results=5  
+    )
+
+    metadatas = results['metadatas']
+    distances = results['distances']
+
+    # Initialize an empty list to store extracted data
+    extracted_data = []
+
+    for meta_list, dist_list in zip(metadatas, distances):
+        for metadata, distance in zip(meta_list, dist_list):
+            name = metadata.get('name', 'N/A')
+            uri = metadata.get('uri', 'N/A')
+            luid = metadata.get('luid', 'N/A')
+            isCertified = metadata.get('isCertified', 'N/A')
+            updatedAt = metadata.get('updatedAt', 'N/A')
+
+            # Append the extracted data to the list, including 'distance'
+            extracted_data.append({
+                'name': name,
+                'uri': uri,
+                'luid': luid,
+                'isCertified': isCertified,
+                'updatedAt': updatedAt,
+                'distance': distance
+            })
+
+    # Render the results template
+    return render_template('results.html', results=extracted_data, query=user_input)
+
+# Run the Flask app
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/chains/query_data_chain/templates/results.html
+++ b/chains/query_data_chain/templates/results.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Search Results</title>
+</head>
+<body>
+    <h1>Search Results</h1>
+    <h2>You searched for: "{{ query }}"</h2>
+    {% if results %}
+        <ul>
+            {% for item in results %}
+                <li>
+                    <strong>Name:</strong> {{ item.name }}<br>
+                    <strong>URI:</strong> {{ item.uri }}<br>
+                    <strong>LUID:</strong> {{ item.luid }}<br>
+                    <strong>Certified?:</strong> {{ item.isCertified }}<br>
+                    <strong>Last Update:</strong> {{ item.updatedAt }}<br>
+                    <strong>Vector Distance:</strong> {{ item.distance }}<br>
+                </li>
+                <hr>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>No results found for "{{ query }}".</p>
+    {% endif %}
+    <a href="/">Back to Search</a>
+</body>
+</html>

--- a/chains/query_data_chain/templates/search.html
+++ b/chains/query_data_chain/templates/search.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Search Tableau Datasources</title>
+</head>
+<body>
+    <h1>Search Tableau Datasources</h1>
+    <form action="/search" method="post">
+        <label for="query">Enter your search query:</label><br><br>
+        <input type="text" id="query" name="query" size="50" required><br><br>
+        <input type="submit" value="Search">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
Adding working example of Tableau Server/Cloud Datasources RAG search (script and flask app)

In practice:
- Connects to tableau server/cloud
- Fetches published datasources via graphql script
- Preps a dictionary of tableau datasources (ids, metadata, field names concatenated) 
- Initialises a vector db (chroma) and preps data for RAG, or uses existing vector db if available
- Queries vector db and returns results + metadata

Script version:
```
cd chains
python query_data_chain\rag_demo.py
```

Flask version:
```
cd chains
python query_data_chain\rag_demo_flask.py
```

Adds modules for:
- graphql interface
- embedding api

Add prompts for:
- published datasources
- dashboards
- sheets
(sheets and dashboards enable development of RAG search for existing server/cloud content)